### PR TITLE
Changes the type of the Sizes parameter

### DIFF
--- a/src/BlazorSplit/BlazorSplit/OptionTypes/NumberOrArray.cs
+++ b/src/BlazorSplit/BlazorSplit/OptionTypes/NumberOrArray.cs
@@ -6,6 +6,11 @@ namespace BlazorSplit.OptionTypes;
 [JsonConverter(typeof(NumberOrArrayJsonConverter))]
 public class NumberOrArray : SingleOrArray<Number>
 {
+    public NumberOrArray(params Number[] values) : base(values)
+    {
+        
+    }
+    
     public NumberOrArray(IEnumerable<Number> values) : base(values)
     {
     }

--- a/src/BlazorSplit/BlazorSplit/Split.razor
+++ b/src/BlazorSplit/BlazorSplit/Split.razor
@@ -17,7 +17,7 @@
     /// Initial sizes of each element in percents or CSS values.
     /// </summary>
     [Parameter]
-    public NumberOrArray? Sizes { get; init; }
+    public IEnumerable<Number>? Sizes { get; init; }
 
     /// <summary>
     /// Minimum size of each element.

--- a/src/BlazorSplit/BlazorSplit/SplitOptions.cs
+++ b/src/BlazorSplit/BlazorSplit/SplitOptions.cs
@@ -58,7 +58,7 @@ public class SplitOptions
     /// Initial sizes of each element in percents or CSS values.
     /// </summary>
     [JsonPropertyName("sizes")]
-    public NumberOrArray? Sizes { get; init; }
+    public IEnumerable<Number>? Sizes { get; init; }
 
     /// <summary>
     /// Snap to minimum size offset in pixels.


### PR DESCRIPTION
Changes the type of the Sizes parameter to require an array. Also updates the NumberOrArray type to accept values as params. Fixes #6 